### PR TITLE
Added API route to save episode watch history at specific duration #50

### DIFF
--- a/Backend/Backend/Controllers/Requests/PodcastRequests.cs
+++ b/Backend/Backend/Controllers/Requests/PodcastRequests.cs
@@ -54,3 +54,9 @@ public class EditEpisodeRequest : CreateEpisodeRequest
 
     public new IFormFile? Thumbnail { get; set; }
 }
+
+[BindProperties]
+public class EpisodeHistorySaveRequest
+{
+    public double ListenPosition { get; set; }
+}

--- a/Backend/Backend/Controllers/Responses/PodcastResponses.cs
+++ b/Backend/Backend/Controllers/Responses/PodcastResponses.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using Backend.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Backend.Controllers.Responses;
 
@@ -10,6 +11,7 @@ public class EpisodeResponse
 
     public EpisodeResponse(Episode e, string domainUrl)
     {
+        Episode = e;
         Id=e.Id;
         PodcastId=e.PodcastId;
         EpisodeName=e.EpisodeName;
@@ -32,6 +34,8 @@ public class EpisodeResponse
     public ulong PlayCount { get; set; } = 0;
     public string AudioUrl { get; set; } = string.Empty;
     public string ThumbnailUrl { get; set; } = string.Empty;
+
+    [BindNever] public Episode Episode { get; private set; } = null!;
 }
 
 [BindProperties]

--- a/Backend/Backend/Infrastructure/AppDbContext.cs
+++ b/Backend/Backend/Infrastructure/AppDbContext.cs
@@ -61,7 +61,10 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<Podcast>().Property(e => e.Tags).HasConversion(
 
             v => string.Join(",", v), v => v.Split(",", StringSplitOptions.RemoveEmptyEntries));
-        
+
+        modelBuilder.Entity<UserEpisodeInteraction>()
+            .HasKey(uei => new { uei.UserId, uei.EpisodeId });
+
         // User 1-to-many Podcast
         modelBuilder.Entity<User>()
             .HasMany(e => e.Podcasts)

--- a/Backend/Backend/Models/Episode.cs
+++ b/Backend/Backend/Models/Episode.cs
@@ -72,13 +72,10 @@ public class Episode : BaseEntity
 
 public class UserEpisodeInteraction : BaseEntity
 {
-    [Key]
-    public Guid Id { get; set; }
-
     public Guid UserId { get; set; }
 
     public User User { get; set; } = null!;
-
+    
     public Guid EpisodeId { get; set; }
 
     [DefaultValue(false)]

--- a/Backend/Backend/Services/Interfaces/IPodcastService.cs
+++ b/Backend/Backend/Services/Interfaces/IPodcastService.cs
@@ -26,4 +26,5 @@ public interface IPodcastService
     public Task<string> GetEpisodeAudioNameAsync(Guid episodeId);
     public Task<string> GetEpisodeThumbnailNameAsync(Guid episodeId);
     public Task<UserEpisodeInteraction?> GetUserEpisodeInteraction(User user, Episode episode);
+    public Task<UserEpisodeInteraction> SaveWatchHistory(User user, Guid episodeId, double listenPosition, string domain);
 }

--- a/Backend/Backend/Services/Interfaces/IPodcastService.cs
+++ b/Backend/Backend/Services/Interfaces/IPodcastService.cs
@@ -25,4 +25,5 @@ public interface IPodcastService
     public Task<EpisodeResponse> GetEpisodeByIdAsync(Guid episodeId, string domainUrl);
     public Task<string> GetEpisodeAudioNameAsync(Guid episodeId);
     public Task<string> GetEpisodeThumbnailNameAsync(Guid episodeId);
+    public Task<UserEpisodeInteraction?> GetUserEpisodeInteraction(User user, Episode episode);
 }

--- a/Backend/Backend/Services/PodcastService.cs
+++ b/Backend/Backend/Services/PodcastService.cs
@@ -571,5 +571,10 @@ public class PodcastService : IPodcastService
         return episode.Thumbnail;
     }
 
+    public async Task<UserEpisodeInteraction?> GetUserEpisodeInteraction(User user, Episode episode)
+    {
+       return await _db.UserEpisodeInteractions!.Where(e => e.UserId == user.Id && e.EpisodeId == episode.Id).FirstOrDefaultAsync();
+    }
+
     #endregion Episode
 }

--- a/backend/Backend.Tests/PodcastTests.cs
+++ b/backend/Backend.Tests/PodcastTests.cs
@@ -48,7 +48,7 @@ public class PodcastTests
         _authServiceMock = new();
         _httpRequestMock  = new();
         _podcastService = new(_dbContextMock.Object);
-        _podcastController = new(_podcastService, _authServiceMock.Object)
+        _podcastController = new(_podcastService, _authServiceMock.Object, _dbContextMock.Object)
         {
             ControllerContext = new ControllerContext()
             {
@@ -67,7 +67,7 @@ public class PodcastTests
         _authServiceMock = new();
         _httpRequestMock = new();
         _podcastService = new(_dbContextMock.Object);
-        _podcastController = new(_podcastService, _authServiceMock.Object) 
+        _podcastController = new(_podcastService, _authServiceMock.Object, _dbContextMock.Object) 
         { 
             ControllerContext = new ControllerContext()
             {

--- a/backend/Backend.Tests/PodcastTests.cs
+++ b/backend/Backend.Tests/PodcastTests.cs
@@ -48,7 +48,7 @@ public class PodcastTests
         _authServiceMock = new();
         _httpRequestMock  = new();
         _podcastService = new(_dbContextMock.Object);
-        _podcastController = new(_podcastService, _authServiceMock.Object, _dbContextMock.Object)
+        _podcastController = new(_podcastService, _authServiceMock.Object)
         {
             ControllerContext = new ControllerContext()
             {
@@ -67,7 +67,7 @@ public class PodcastTests
         _authServiceMock = new();
         _httpRequestMock = new();
         _podcastService = new(_dbContextMock.Object);
-        _podcastController = new(_podcastService, _authServiceMock.Object, _dbContextMock.Object) 
+        _podcastController = new(_podcastService, _authServiceMock.Object) 
         { 
             ControllerContext = new ControllerContext()
             {


### PR DESCRIPTION
## On the frontend:
You need to add a onBeforeUnload  hook to the episode webpage and this hook should send request to this route.
OR
You can call this API route periodically (e.g. when the user had watched 30 sec)