### PR TITLE
Create helpers and response modules for episode transcripts

### DIFF
--- a/frontend/components/nowPlaying/Transcripts.tsx
+++ b/frontend/components/nowPlaying/Transcripts.tsx
@@ -3,18 +3,38 @@ import { Box, Text, Flex, Icon, useBreakpointValue } from "@chakra-ui/react";
 import { IoMicOutline } from "react-icons/io5";
 import { TranscriptLine } from "../../utilities/Interfaces";
 import { convertTime } from "../../utilities/commonUtils";
+import { useState, useEffect } from "react";
+import PodcastHelper from "../../helpers/PodcastHelper";
 
 // Define the props for the Transcripts component
 interface TranscriptsProps {
+  episodeId: string;
   transcripts: TranscriptLine[]; // The array of transcript lines
 }
 
 // Transcripts component
-const Transcripts: React.FC<TranscriptsProps> = ({ transcripts }) => {
+const Transcripts: React.FC<TranscriptsProps> = ({ episodeId, transcripts }) => {
   const fontSize = useBreakpointValue({ base: "md", md: "lg" }); // Font size based on breakpoint
   const iconSize = useBreakpointValue({ base: "16px", md: "24px" }); // Icon size based on breakpoint
 
   const opacityLevels = [1, 0.4, 0.1]; // Opacity levels for different transcript lines
+
+  const [transcript, setTranscript] = useState(null);
+
+  useEffect(() => {
+    if (episodeId) {
+      PodcastHelper.getTranscript(episodeId)
+        .then((res) => {
+          if (res.status === 200) {
+            setTranscript(res.transcript);
+          } else {
+            console.error("Error fetching section data:", res.message);
+          }
+        })
+        .catch((error) => console.error("Error fetching section data:", error));
+    }
+  }, [episodeId]);
+
 
   return (
     <Box

--- a/frontend/helpers/EndpointHelper.tsx
+++ b/frontend/helpers/EndpointHelper.tsx
@@ -579,4 +579,17 @@ export default class EndpointHelper {
   static getLikedEpisodesPlaylistEndpoint = () => {
     return this.getBackendAddress() + "/playlist/getLikedEpisodesPlaylist";
   };
+
+  // --------------------------------
+  // TRANSCRIPT ENDPOINT
+  // --------------------------------
+  /**
+   * Returns the Episode Transcript endpoint.
+   * @returns The Episode Transcript Endpoint
+   * */
+  static getTranscriptEndpoint = (episodeId) => {
+    return this.getBackendAddress() + "/podcast/" + episodeId + "/getTranscript";
+  };
+
 }
+

--- a/frontend/helpers/PodcastHelper.tsx
+++ b/frontend/helpers/PodcastHelper.tsx
@@ -13,6 +13,7 @@ import {
   EditEpisodeResponse,
   GetMyEpisodeResponse,
   EditPodcastResponse,
+  GetTranscriptResponse,
 } from "../utilities/Responses";
 
 export default class PodcastHelper {
@@ -584,4 +585,48 @@ export default class PodcastHelper {
       };
     }
   };
+
+  /**
+  * Gets an episode transcript by episodeId from the server.
+  * @returns A BaseResponse object with the server's response.
+  */
+  public static getTranscript = async (
+    episodeId,
+    ): Promise<GetTranscriptResponse> => {
+    const options = {
+      method: "GET",
+      headers: {
+        accept: "*/*",
+        "Content-Type": "application/json",
+      },
+      url: EndpointHelper.getTranscriptEndpoint(episodeId),
+      withCredentials: true, // This will send the session cookie with the request
+      cache: false,
+    };
+
+    try {
+      console.debug("Sending the following getTrasncript...");
+      console.debug(options);
+
+      // Send the request and wait for the response.
+      const requestResponse = await axios(options);
+
+      console.debug("Received the following getTranscript...");
+      console.debug(requestResponse);
+
+      // Return the response.
+      return {
+        status: requestResponse.status,
+        message: requestResponse.statusText,
+        transcript: requestResponse.data,
+      };
+    } catch (error) {
+      return {
+        status: error.response?.status,
+        message: error.response?.statusText,
+        transcript: null,
+      };
+    }
+  };
+  
 }

--- a/frontend/utilities/Responses.tsx
+++ b/frontend/utilities/Responses.tsx
@@ -9,6 +9,7 @@ import {
   Bookmark,
   Section,
   Playlist,
+  TranscriptLine
 } from "./Interfaces";
 
 export interface BaseResponse {
@@ -158,5 +159,10 @@ export interface GetPlaylistEpisodesResponse extends BaseResponse {
 }
 
 //#endregion
+
+//#region Transcript Responses
+export interface GetTranscriptResponse extends BaseResponse {
+  transcript: TranscriptLine;
+}
 
 //#endregion


### PR DESCRIPTION
This PR introduces episode transcript behind-the-scene implementation to the frontend, it allows users to get an episode transcript. The UI module is to be worked on later.

Feature:

Getting an episode transcript

Implementation:
Modified Transcript component
Added get Transcript to the Endpoint Helper
Added GET Response to Transcript Component using Podcast Helper
Created Response Interfaces for Transcript

works on https://github.com/awaazo/awaazo/issues/168