### PR TITLE
Added instructions on how to run Awaazo

### DIFF
--- a/Python/Dockerfile
+++ b/Python/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04
 WORKDIR /app
 ADD . /app
 
-# Install Python3.11 & ffmpeg
+# Install Python3.9 & ffmpeg
 RUN \
 --mount=type=cache,target=/var/cache/apt \
 apt-get -y update && apt-get install -y python3.9 \

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The following links can be used to download Docker:
 
 #### <h2>Nvidia CUDA enabled GPU</h2>
 
-Awaazo makes heavy usre of Artificial Intelligence (AI) and therefore utilizes GPU resources to speed up the computation time. Although having a CUDA enabled GPU is not required, it is <b>STRONGLY ADVISED</b>.
+Awaazo extensively employs AI and machine learning models, leveraging GPU resources to significantly enhance computation speed. While a CUDA-enabled GPU is not mandatory, its use is <b>highly recommended</b> to achieve superior performance and faster processing speeds.
 
 - [Download CUDA Toolkit](https://developer.nvidia.com/cuda-downloads?)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,54 @@ For complete details, refer to our [Tech Stack Wiki](https://github.com/awaazo/a
 
 <br>
 
+
+## Setup Instructions to run Awaazo
+
+The following steps show how to run Awaazo on your local machine using Docker.
+
+### Prerequisites:
+
+#### <h2>Docker <img src="https://1000logos.net/wp-content/uploads/2021/11/Docker-Logo-2013.png"  height= 50px/></h2>
+
+Awaazo runs on Docker, which means that it must be installed on your local machine. 
+The following links can be used to download Docker:
+- [Download for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&amp;utm_medium=webreferral&amp;utm_campaign=dd-smartbutton&amp;utm_location=module)
+- [Download for Linux](https://docs.docker.com/desktop/linux/install/)
+- [Mac - Intel Chip](https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&amp;utm_medium=webreferral&amp;utm_campaign=dd-smartbutton&amp;utm_location=module&amp;_gl=1*1gb7bzl*_ga*MTg5NDc4NDMyLjE2ODQ1MTc4OTE.*_ga_XJWPQMJYHQ*MTcwNTMzMzA4Ni40Ni4xLjE3MDUzMzMwOTYuNTAuMC4w)
+- [Mac - Apple Chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&amp;utm_medium=webreferral&amp;utm_campaign=dd-smartbutton&amp;utm_location=module)
+
+#### <h2>Nvidia CUDA enabled GPU</h2>
+
+Awaazo makes heavy usre of Artificial Intelligence (AI) and therefore utilizes GPU resources to speed up the computation time. Although having a CUDA enabled GPU is not required, it is <b>STRONGLY ADVISED</b>.
+
+- [Download CUDA Toolkit](https://developer.nvidia.com/cuda-downloads?)
+
+### Installation:
+
+The installation process pulls the latest Docker images from Awaazo's main branch. Make sure that Docker is running before doing the next steps.
+
+#### Windows
+- Download the [docker-compose file for GPU support](https://github.com/awaazo/awaazo/blob/main/docker-compose.latest.yml) or for [CPU-only support](https://github.com/awaazo/awaazo/blob/main/docker-compose.latest-cpu-only.yml).
+- Open a terminal and set the current working directory to where the docker-compose file is located.
+- Run the following command to start Awaazo: ```docker-compose -f docker-compose.latest.yml up```
+- To close Awaazo, run the following command: ```docker-compose -f docker-compose.latest.yml down```
+
+#### Linux
+- Download the [docker-compose file for GPU support](https://github.com/awaazo/awaazo/blob/main/docker-compose.latest.yml) or for [CPU-only support](https://github.com/awaazo/awaazo/blob/main/docker-compose.latest-cpu-only.yml).
+- Open a terminal and set the current working directory to where the docker-compose file is located.
+- Run the following command to start Awaazo: ```sudo docker-compose -f docker-compose.latest.yml up```
+- To close Awaazo, run the following command: ```sudo docker-compose -f docker-compose.latest.yml down```
+
+#### Mac
+
+- Download the [docker-compose file](https://github.com/awaazo/awaazo/blob/main/docker-compose.macos-latest.yml).
+- Open a terminal and set the current working directory to where the docker-compose file is located.
+- Run the following command to start Awaazo: ```sudo docker-compose -f docker-compose.latest.yml up```
+- To close Awaazo, run the following command: ```sudo docker-compose -f docker-compose.latest.yml down```
+
+
+<br>
+
 ## Team Members
 
 

--- a/docker-compose.latest-cpu-only.yml
+++ b/docker-compose.latest-cpu-only.yml
@@ -1,11 +1,9 @@
-# Docker Compose file for Awaazo application
-#
-# Usage:
-#   docker-compose -f docker-compose.macos.yml up         
-#   docker-compose -f docker-compose.macos.yml down
-#   docker-compose -f docker-compose.macos.yml ps
-#   docker-compose -f docker-compose.macos.yml logs
-#   docker-compose -f docker-compose.macos.yml up --build -d
+# This Docker Compose file is used to define and manage the services required for the Awaazo application.
+# It sets up the following services:
+# - SQL Server: A Microsoft SQL Server container for the database.
+# - Python Server: A server for AI-related tasks.
+# - Backend ASP.NET Server: The backend server for the Awaazo application.
+# - Frontend Server: The frontend server for the Awaazo application.
 
 version: '3.8'
 
@@ -23,26 +21,23 @@ services:
       ACCEPT_EULA: "y"
       SA_PASSWORD: "MyPass@word" # For local dev ONLY. DO NOT SHARE ANY CREDENTIALS
     volumes:
-      - "./mount/sql:/var/opt/mssql/data" # Modified volume path for macOS
+      - "//c/mount/sql:/var/opt/mssql/data"
     restart: on-failure:5
 
   # PYTHON Server (For AI related Stuff)
   python_backend:
     platform: linux/amd64
-    build: 
-      context: Python/.
+    image: ghcr.io/awaazo/py_backend:latest
     container_name: python_server
     ports:
       - "8500:8000"
     volumes:
-      - "./backend_server/ServerFiles:/app/ServerFiles" # Modified volume path for macOS
+      - "//c/backend_server/ServerFiles:/app/ServerFiles"
 
   # BACKEND ASP.NET Server
   backend:
     platform: linux/amd64
-    build:
-      context: Backend/Backend/.
-      target: final
+    image: ghcr.io/awaazo/backend:latest
     container_name: backend_server
     ports:
       - "32773:80"
@@ -51,9 +46,9 @@ services:
       - sql:sql_server
       - python_backend:py
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
     volumes:
-      - "./backend_server/ServerFiles:/app/ServerFiles" # Modified volume path for macOS
+      - "//c/backend_server/ServerFiles:/app/ServerFiles"
     depends_on:
       - sql 
     restart: on-failure:5
@@ -61,8 +56,7 @@ services:
   # FRONTEND SERVER
   frontend:
     platform: linux/amd64
-    build: 
-      context: frontend/.
+    image: ghcr.io/awaazo/frontend:latest
     container_name: frontend_server
     environment:
       NODE_ENV: production
@@ -71,6 +65,5 @@ services:
     links:
       - backend:backend_server
     depends_on:
-      - backend
       - backend
     restart: on-failure:5

--- a/docker-compose.latest.yml
+++ b/docker-compose.latest.yml
@@ -1,11 +1,9 @@
-# Docker Compose file for Awaazo application
-#
-# Usage:
-#   docker-compose -f docker-compose.macos.yml up         
-#   docker-compose -f docker-compose.macos.yml down
-#   docker-compose -f docker-compose.macos.yml ps
-#   docker-compose -f docker-compose.macos.yml logs
-#   docker-compose -f docker-compose.macos.yml up --build -d
+# This Docker Compose file is used to define and manage the services required for the Awaazo application.
+# It sets up the following services:
+# - SQL Server: A Microsoft SQL Server container for the database.
+# - Python Server: A server for AI-related tasks.
+# - Backend ASP.NET Server: The backend server for the Awaazo application.
+# - Frontend Server: The frontend server for the Awaazo application.
 
 version: '3.8'
 
@@ -23,26 +21,30 @@ services:
       ACCEPT_EULA: "y"
       SA_PASSWORD: "MyPass@word" # For local dev ONLY. DO NOT SHARE ANY CREDENTIALS
     volumes:
-      - "./mount/sql:/var/opt/mssql/data" # Modified volume path for macOS
+      - "//c/mount/sql:/var/opt/mssql/data"
     restart: on-failure:5
 
   # PYTHON Server (For AI related Stuff)
   python_backend:
     platform: linux/amd64
-    build: 
-      context: Python/.
+    image: ghcr.io/awaazo/py_backend:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     container_name: python_server
     ports:
       - "8500:8000"
     volumes:
-      - "./backend_server/ServerFiles:/app/ServerFiles" # Modified volume path for macOS
+      - "//c/backend_server/ServerFiles:/app/ServerFiles"
 
   # BACKEND ASP.NET Server
   backend:
     platform: linux/amd64
-    build:
-      context: Backend/Backend/.
-      target: final
+    image: ghcr.io/awaazo/backend:latest
     container_name: backend_server
     ports:
       - "32773:80"
@@ -51,9 +53,9 @@ services:
       - sql:sql_server
       - python_backend:py
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
     volumes:
-      - "./backend_server/ServerFiles:/app/ServerFiles" # Modified volume path for macOS
+      - "//c/backend_server/ServerFiles:/app/ServerFiles"
     depends_on:
       - sql 
     restart: on-failure:5
@@ -61,8 +63,7 @@ services:
   # FRONTEND SERVER
   frontend:
     platform: linux/amd64
-    build: 
-      context: frontend/.
+    image: ghcr.io/awaazo/frontend:latest
     container_name: frontend_server
     environment:
       NODE_ENV: production
@@ -71,6 +72,5 @@ services:
     links:
       - backend:backend_server
     depends_on:
-      - backend
       - backend
     restart: on-failure:5

--- a/docker-compose.macos-latest.yml
+++ b/docker-compose.macos-latest.yml
@@ -29,8 +29,7 @@ services:
   # PYTHON Server (For AI related Stuff)
   python_backend:
     platform: linux/amd64
-    build: 
-      context: Python/.
+    image: ghcr.io/awaazo/py_backend:latest
     container_name: python_server
     ports:
       - "8500:8000"
@@ -40,9 +39,7 @@ services:
   # BACKEND ASP.NET Server
   backend:
     platform: linux/amd64
-    build:
-      context: Backend/Backend/.
-      target: final
+    image: ghcr.io/awaazo/backend:latest
     container_name: backend_server
     ports:
       - "32773:80"
@@ -51,7 +48,7 @@ services:
       - sql:sql_server
       - python_backend:py
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
     volumes:
       - "./backend_server/ServerFiles:/app/ServerFiles" # Modified volume path for macOS
     depends_on:
@@ -61,8 +58,7 @@ services:
   # FRONTEND SERVER
   frontend:
     platform: linux/amd64
-    build: 
-      context: frontend/.
+    image: ghcr.io/awaazo/frontend:latest
     container_name: frontend_server
     environment:
       NODE_ENV: production
@@ -71,6 +67,5 @@ services:
     links:
       - backend:backend_server
     depends_on:
-      - backend
       - backend
     restart: on-failure:5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   # DATABASE (MSSQL)
   sql:
+    platform: linux/amd64
     image: "mcr.microsoft.com/mssql/server:latest"
     container_name: sql_server
     user: root
@@ -42,6 +43,7 @@ services:
 
   # PYTHON Server (For AI related Stuff)
   python_backend:
+    platform: linux/amd64
     build: 
       context: Python/.
     deploy:
@@ -59,6 +61,7 @@ services:
 
   # BACKEND ASP.NET Server
   backend:
+    platform: linux/amd64
     build:
       context: Backend/Backend/.
       target: final
@@ -79,6 +82,7 @@ services:
 
   # FRONTEND SERVER
   frontend:
+    platform: linux/amd64
     build: 
       context: frontend/.
     container_name: frontend_server


### PR DESCRIPTION
- Added docker-compose file for different use cases.
- Added instruction on how to run Awaazo to the readme: The instruction provided just enough information to allow a user to use/run the application. It does not give development instructions as this would force us to reveal our application secrets.