### PR TITLE
Fixed podcast delete error

### DIFF
--- a/Backend/Backend/Infrastructure/AppDbContext.cs
+++ b/Backend/Backend/Infrastructure/AppDbContext.cs
@@ -141,6 +141,7 @@ public class AppDbContext : DbContext
             .WithOne(e => e.User)
             .HasForeignKey(e => e.UserId)
             .IsRequired();
+
         
         // User 1-to-many UserEpisodeInteraction 
         modelBuilder.Entity<User>()
@@ -222,7 +223,7 @@ public class AppDbContext : DbContext
             .HasMany(e => e.Ratings)
             .WithOne(e => e.Podcast)
             .HasForeignKey(e => e.PodcastId)
-            .OnDelete(DeleteBehavior.Restrict);
+            .OnDelete(DeleteBehavior.Cascade);
 
         // Rating many-to-1 user
         modelBuilder.Entity<User>()

--- a/Backend/Backend/Migrations/20240116003604_firstMigration.Designer.cs
+++ b/Backend/Backend/Migrations/20240116003604_firstMigration.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Backend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20240109153434_firstMigration")]
+    [Migration("20240116003604_firstMigration")]
     partial class firstMigration
     {
         /// <inheritdoc />
@@ -919,7 +919,7 @@ namespace Backend.Migrations
                     b.HasOne("Backend.Models.Podcast", "Podcast")
                         .WithMany("Ratings")
                         .HasForeignKey("PodcastId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("Backend.Models.User", "User")

--- a/Backend/Backend/Migrations/20240116003604_firstMigration.cs
+++ b/Backend/Backend/Migrations/20240116003604_firstMigration.cs
@@ -248,7 +248,7 @@ namespace Backend.Migrations
                         column: x => x.PodcastId,
                         principalTable: "Podcasts",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_PodcastRatings_Users_UserId",
                         column: x => x.UserId,

--- a/Backend/Backend/Migrations/AppDbContextModelSnapshot.cs
+++ b/Backend/Backend/Migrations/AppDbContextModelSnapshot.cs
@@ -916,7 +916,7 @@ namespace Backend.Migrations
                     b.HasOne("Backend.Models.Podcast", "Podcast")
                         .WithMany("Ratings")
                         .HasForeignKey("PodcastId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("Backend.Models.User", "User")


### PR DESCRIPTION
- The error was caused by the on delete policy for podcasts in regards to ratings. It was set to restrict, which will set the podcastId for the rating to null. Because the podcastId is not nullable, that was preventing the saveChanges() from working, which threw an exception.
- It was fixed by changing the on delete policy to cascade, which deletes all ratings associated with the given podcast.