### PR TITLE
#466 Added 2 admin endpoints for user metrics

### DIFF
--- a/Backend/Backend/Controllers/AdminPanelController.cs
+++ b/Backend/Backend/Controllers/AdminPanelController.cs
@@ -203,6 +203,11 @@ public class AdminPanelController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Returns total amount of users in the database. Includes admins
+    /// </summary>
+    /// <param name="withDeleted">Value to check if we wanted soft deleted users as well. Defaults to no</param>
+    /// <returns></returns>
     [HttpGet("GetTotalUsers")]
     public async Task<IActionResult> GetTotalUsers(bool withDeleted = false)
     {
@@ -220,6 +225,11 @@ public class AdminPanelController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Gets the amount of recently created users in the database. Includes admins
+    /// </summary>
+    /// <param name="daySinceCreation">Positive interger defaulting to 1 that shows from how many days ago we are searching</param>
+    /// <returns></returns>
     [HttpGet("GetRecentlyCreatedUserCount")]
     public async Task<IActionResult> GetRecentlyCreatedUserCount(int daySinceCreation = 1)
     {

--- a/Backend/Backend/Controllers/AdminPanelController.cs
+++ b/Backend/Backend/Controllers/AdminPanelController.cs
@@ -158,7 +158,6 @@ public class AdminPanelController : ControllerBase
         try
         {
             this.LogDebugControllerAPICall(_logger);
-            var admin = await IdentifyAdminAsync();
 
             var result = await _adminService.CreateDailyPodcastRecomendationAsync(request, ControllerHelper.GetDomainUrl(HttpContext));
             return Ok(result);
@@ -176,7 +175,6 @@ public class AdminPanelController : ControllerBase
         try
         {
             this.LogDebugControllerAPICall(_logger);
-            var admin = await IdentifyAdminAsync();
 
             var result = await _adminService.GetDailyPodcastRecomendationsAsync(ControllerHelper.GetDomainUrl(HttpContext));
             return Ok(result);
@@ -194,10 +192,43 @@ public class AdminPanelController : ControllerBase
         try
         {
             this.LogDebugControllerAPICall(_logger);
-            var admin = await IdentifyAdminAsync();
 
             await _adminService.RemoveDailyPodcastRecomendationsAsync(request.podcastsToRemove);
             return Ok();
+        }
+        catch (Exception e)
+        {
+            this.LogErrorAPICall(_logger, e);
+            return BadRequest(e.Message);
+        }
+    }
+
+    [HttpGet("GetTotalUsers")]
+    public async Task<IActionResult> GetTotalUsers(bool withDeleted = false)
+    {
+        try
+        {
+            this.LogDebugControllerAPICall(_logger);
+
+            var totalUsers = await _adminService.GetTotalUsersAsync(withDeleted);
+            return Ok(totalUsers);
+        }
+        catch (Exception e)
+        {
+            this.LogErrorAPICall(_logger, e);
+            return BadRequest(e.Message);
+        }
+    }
+
+    [HttpGet("GetRecentlyCreatedUserCount")]
+    public async Task<IActionResult> GetRecentlyCreatedUserCount(int daySinceCreation = 1)
+    {
+        try
+        {
+            this.LogDebugControllerAPICall(_logger);
+
+            var totalUsers = await _adminService.GetRecentlyCreatedUserCountAsync(daySinceCreation);
+            return Ok(totalUsers);
         }
         catch (Exception e)
         {

--- a/Backend/Backend/Controllers/AdminPanelController.cs
+++ b/Backend/Backend/Controllers/AdminPanelController.cs
@@ -246,4 +246,25 @@ public class AdminPanelController : ControllerBase
             return BadRequest(e.Message);
         }
     }
+
+    /// <summary>
+    /// Endpoint that gets the total amount of users who are creators/podcasters
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("GetTotalAmountOfPodcasters")]
+    public async Task<IActionResult> GetTotalAmountOfPodcasters()
+    {
+        try
+        {
+            this.LogDebugControllerAPICall(_logger);
+
+            var totalUsers = await _adminService.GetTotalAmountOfPodcastersAsync();
+            return Ok(totalUsers);
+        }
+        catch (Exception e)
+        {
+            this.LogErrorAPICall(_logger, e);
+            return BadRequest(e.Message);
+        }
+    }
 }

--- a/Backend/Backend/Services/AdminPanelService.cs
+++ b/Backend/Backend/Services/AdminPanelService.cs
@@ -202,6 +202,38 @@ public class AdminPanelService
         return await _db.SaveChangesAsync() == oldRecommendations.Count;
     }
 
+    /// <summary>
+    /// Get the total amount of users in the database. This includes admins.
+    /// </summary>
+    /// <param name="withDeleted">Optional parameter to include softdeleted users</param>
+    /// <returns></returns>
+    public async Task<int> GetTotalUsersAsync(bool withDeleted = false)
+    {
+        int totalUserCount = 0;
+        if (withDeleted)
+        {
+            totalUserCount = await _db.Users.IgnoreQueryFilters().CountAsync();
+            return totalUserCount;
+        }
+
+        totalUserCount = await _db.Users.CountAsync();
+        return totalUserCount;
+    }
+
+    /// <summary>
+    /// Returns the amount of users created since a certain amount of days, not counting admins
+    /// </summary>
+    /// <param name="daysSinceCreation">Threashold for the search, in terms of days</param>
+    /// <returns></returns>
+    public async Task<List<User>> GetRecentlyCreatedUserCountAsync(int daysSinceCreation)
+    {
+        var totalUserCount = await _db.Users
+            .Where(u => u.IsAdmin == false && u.CreatedAt >= DateTime.Now.AddDays(-daysSinceCreation))
+            .ToListAsync();
+
+        return totalUserCount;
+    }
+
     #endregion
 
     public Task<AdminEmailLog[]> EmailLogs(User admin, int page) {

--- a/Backend/Backend/Services/AdminPanelService.cs
+++ b/Backend/Backend/Services/AdminPanelService.cs
@@ -221,14 +221,14 @@ public class AdminPanelService
     }
 
     /// <summary>
-    /// Returns the amount of users created since a certain amount of days, not counting admins
+    /// Returns the amount of users created since a certain amount of days, counting admins as well
     /// </summary>
     /// <param name="daysSinceCreation">Threashold for the search, in terms of days</param>
     /// <returns></returns>
     public async Task<List<User>> GetRecentlyCreatedUserCountAsync(int daysSinceCreation)
     {
         var totalUserCount = await _db.Users
-            .Where(u => u.IsAdmin == false && u.CreatedAt >= DateTime.Now.AddDays(-daysSinceCreation))
+            .Where(u => u.CreatedAt >= DateTime.Now.AddDays(-daysSinceCreation))
             .ToListAsync();
 
         return totalUserCount;


### PR DESCRIPTION
Closes #466 
Added 2 endpoints for admin to get data regarding user metrics
- `admin/GetTotalUsers`  To get total user count in the system, counting admins
- `admin/GetRecentlyCreatedUserCount` To get recently created users, with a modifiable date threshold. Admins are counted as well
- `admin/GetTotalAmountOfPodcasters` to get the amount of podcasters in the database